### PR TITLE
Ignore sysctl for openvz containers

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -36,7 +36,7 @@ end
 
 # RHEL7 has some extra requriements per
 # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Storage_Administration_Guide/nfs-serverconfig.html#s2-nfs-nfs-firewall-config
-if node['platform_family'] == 'rhel' && node['platform_version'].to_f >= 7.0 && node['platform'] != 'amazon'
+if node['platform_family'] == 'rhel' && node['platform_version'].to_f >= 7.0 && node['platform'] != 'amazon' && node['virtualization']['system'] != 'openvz'
   include_recipe 'sysctl::default'
 
   sysctl_param 'fs.nfs.nlm_tcpport' do


### PR DESCRIPTION
Hello,

for OpenVZ/Virtuozzo containers sysctl `fs.nfs.nlm_tcpport` is read only.

```
# sysctl  -w fs.nfs.nlm_tcpport=32768
sysctl: permission denied on key 'fs.nfs.nlm_tcpport'
```

This PR filter OpenVZ containers.